### PR TITLE
Fixes 404 to pair analytics

### DIFF
--- a/src/pages/Swap/PairAnalyticsLink.tsx
+++ b/src/pages/Swap/PairAnalyticsLink.tsx
@@ -16,7 +16,7 @@ export const PairAnalyticsLink: React.FC<{ pairAddress: string }> = ({ pairAddre
         padding: '6px',
       }}
     >
-      <a href={`https://secretanalytics.xyz/secretswap/${pairAddress}`} target="_blank">
+      <a href={`https://secretanalytics.xyz/${pairAddress}`} target="_blank">
         <strong>View pair analytics ↗</strong>
       </a>
     </div>


### PR DESCRIPTION
eg [sSCRT-sETH](https://secretanalytics.xyz/secret14zv2fdsfwqzxqt7s2ushp4c4jr56ysyld5zcdf)