### PR TITLE
Set Bridge Earn rewards to 0%

### DIFF
--- a/src/components/Earn/EarnRow/index.tsx
+++ b/src/components/Earn/EarnRow/index.tsx
@@ -33,13 +33,9 @@ export const calculateAPY = (token: RewardsToken, price: number, priceUnderlying
 };
 
 export const apyString = (token: RewardsToken) => {
-  const apy = Number(calculateAPY(token, Number(token.rewardsPrice), Number(token.price)));
-  if (isNaN(apy) || 0 > apy) {
-    return '0%';
-  }
-
+  // Bridge Earn rewards have been disabled
+  const apy = Number(0)
   const apyStr = zeroDecimalsFormatter.format(apy);
-
   return `${apyStr}%`;
 };
 interface RewardsToken {


### PR DESCRIPTION
@reuvenpo @assafmo 

We're getting a LOT of frustrated people in Discord due to the APY being wrong. In addition, some people are selling their liquidity in order to get into the Bridge Earn page, due to the incorrect APY. Example: https://discord.com/channels/360051864110235648/360051864110235649/894167472293441587

This PR simply changes the APY to be correct, 0%.

Signed-off-by: Dylan Schultz <dylanschultz311@gmail.com>